### PR TITLE
Add El Camino College (elcamino.edu)

### DIFF
--- a/lib/domains/edu/elcamino.txt
+++ b/lib/domains/edu/elcamino.txt
@@ -1,0 +1,1 @@
+El Camino College


### PR DESCRIPTION
Add El Camino College domain: `elcamino.edu`

URL confirming that `elcamino.edu` is the email domain given to students - https://www.elcamino.edu/departments/its/student-resources.aspx
> All active ECC students are provided with a College email account (@elcamino.edu). ECC's official means of communication with students is through their student email account. 

Programs which including programming and potential usage of the JetBrains family of tools include:
- https://www.elcamino.edu/academics/areas-of-study/electronics-and-computer-hardware-technology.aspx
- https://www.elcamino.edu/academics/areas-of-study/computer-science.aspx
- https://www.elcamino.edu/academics/areas-of-study/computer-information-systems.aspx